### PR TITLE
bug_fixes

### DIFF
--- a/misp/info.json
+++ b/misp/info.json
@@ -568,8 +568,8 @@
                 "visible": true,
                 "type": "integer",
                 "name": "page",
-                "description": "Specify page number from which you want to retrieve data form MISP.",
-                "tooltip": "Specify page number from which you want to retrieve data form MISP. By default it is set to 1",
+                "description": "Specify page number from which you want to retrieve data form MISP. By default it is set to 1",
+                "tooltip": "Specify page number from which you want to retrieve data form MISP.",
                 "value": 1
               },
               {
@@ -579,8 +579,8 @@
                 "visible": true,
                 "type": "integer",
                 "name": "limit",
-                "description": "Specify the maximum number of records to be retrieved from MISP.",
-                "tooltip": "Specify the maximum number of records to be retrieved from MISP. By default it is set to 10.",
+                "description": "Specify the maximum number of records to be retrieved from MISP. By default it is set to 10.",
+                "tooltip": "Specify the maximum number of records to be retrieved from MISP.",
                 "value": 10
               }
             ],

--- a/misp/info.json
+++ b/misp/info.json
@@ -569,8 +569,8 @@
                 "type": "integer",
                 "name": "page",
                 "description": "Specify page number from which you want to retrieve data form MISP.",
-                "tooltip": "Specify page number from which you want to retrieve data form MISP.",
-                "value": 0
+                "tooltip": "Specify page number from which you want to retrieve data form MISP. By default it is set to 1",
+                "value": 1
               },
               {
                 "title": "Limit",
@@ -580,7 +580,7 @@
                 "type": "integer",
                 "name": "limit",
                 "description": "Specify the maximum number of records to be retrieved from MISP.",
-                "tooltip": "Specify the maximum number of records to be retrieved from MISP.",
+                "tooltip": "Specify the maximum number of records to be retrieved from MISP. By default it is set to 10.",
                 "value": 10
               }
             ],

--- a/misp/operations.py
+++ b/misp/operations.py
@@ -70,8 +70,10 @@ class MISP(object):
     def build_payload(self, payload):
         data = {}
         for k, v in payload.items():
-            if v and (k == 'page' and v < 0) or (k == 'limit' and v <= 0):
+            if v and ((k == 'page' and v < 0) or (k == 'limit' and v <= 0)):
                 raise ConnectorError('Value {0} of {1} parameter is invalid.'.format(v, k))
+            elif type(v) is bool:
+                data[k] = v
             elif v:
                 data[k] = v
         logger.debug("Query Parameters: {0}".format(payload))
@@ -252,11 +254,11 @@ def run_search(config, params):
             searchDatefrom = params.get('from')
             searchDateuntil = params.get('to')
             payload = {
-                "page": params.get('page'),
-                "limit": params.get('limit'),
+                "page": params.get('page', 1),
+                "limit": params.get('limit', 10),
                 "from": arrow.get(searchDatefrom).format('YYYY-MM-DD') if searchDatefrom else None,
                 "to": arrow.get(searchDateuntil).format('YYYY-MM-DD') if searchDateuntil else None,
-                "type": params.get('type', ''),
+                "type": params.get('type', '')
             }
         payload = mp.build_payload(payload)
         search = params.get('controller')

--- a/misp/playbooks/playbooks.json
+++ b/misp/playbooks/playbooks.json
@@ -133,6 +133,8 @@
                 "name": "MISP",
                 "config": "",
                 "params": {
+                  "page": 1,
+                  "limit": 10,
                   "controller": "Events",
                   "search_type": "Basic"
                 },

--- a/misp/release_notes.md
+++ b/misp/release_notes.md
@@ -1,7 +1,7 @@
 #### What's Improved
 - Updated the "Run Search" operation as follows:
   - Added new parameter `Search Type` parameter with Basic and Advanced options:
-  - Added `Search From`, `Search Until`, `Attribute Type`, `Page` and `Limit` parameters for Basic Search.
-  - Added `Search Filter` parameter for advanced search.
-  - Update output schemas.
+    - Added `Search From`, `Search Until`, `Attribute Type`, `Page` and `Limit` parameters for Basic Search.
+    - Added `Search Filter` parameter for advanced search.
+- Update output schemas for all actions.
  

--- a/misp/release_notes.md
+++ b/misp/release_notes.md
@@ -3,3 +3,5 @@
   - Added new parameter `Search Type` parameter with Basic and Advanced options:
   - Added `Search From`, `Search Until`, `Attribute Type`, `Page` and `Limit` parameters for Basic Search.
   - Added `Search Filter` parameter for advanced search.
+  - Update output schemas.
+ 


### PR DESCRIPTION
### Descriptions:

#### Changes:
- Updated description and default value of `Page` and `Limit` parameters in `Run Search` action.
- Fixed a bug where `Run Search` action should fail for invalid `Page` and `Limit` value with proper error message.
- Updated release notes.

#### UTCs:
- Verified tooltip of `Page` and `Limit` parameters in `Run Search` action.
- Tested and verified `Run Search` action with valid and invalid input for `Page` and `Limit` parameter